### PR TITLE
implement send_money and refactored get/post error handling

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,20 +41,16 @@ function Coinbase (options) {
     }
 
     request.get(reqObject, function (err, res, data) {
-      if (err) {
-        callback(err);
-      } else {
-        try {
-          data = JSON.parse(data);
-          if (data.success === false) {
-            callback(new CoinbaseError(data.errors || data.error))
-          } else {
-            callback(null, data);
-          }
-        } catch (err) {
-          callback(err);
-        }
+      if (err) { return callback(err); }
+      try {
+        data = JSON.parse(data);
+      } catch (parseError) {
+        return callback(parseError);
       }
+      
+      if (data.success === false) { return callback(new CoinbaseError(data.errors || data.error)); }
+      
+      callback(null, data);
     });
   }
 
@@ -76,26 +72,18 @@ function Coinbase (options) {
     };
 
     request.post(reqObject, function (err, res, data) {
-      if (err) {
-        callback(err);
-      } else if (res.statusCode !== 200) {
-        callback(new CoinbaseError(res.headers.status));
-      } else{
-        try {
-          data = JSON.parse(data);
-          if (data.success === false) {
-            callback(new CoinbaseError(data.errors || data.error));
-          } else {
-            callback(null, data);
-          }
-        } catch (err) {
-          if (data.errors) {
-            callback(new CoinbaseError(data.errors));
-          } else {
-            callback(data);
-          }
-        }
+      if (err) { return callback(err); }
+      if (res.statusCode !== 200) return callback(new CoinbaseError(res.headers.status));
+      try {
+        data = JSON.parse(data);
+      } catch (parseError) {
+        return callback(parseError);
       }
+
+      if (data.success === false) { return callback(new CoinbaseError(data.errors || data.error)); }
+      if (data.errors) { return callback(new CoinbaseError(data.errors)); }
+      
+      callback(null, data);
     });
   }
 
@@ -284,6 +272,15 @@ function Coinbase (options) {
     log('get ' + url);
 
     get(url, callback);
+  };
+
+  /* POST /api/v1/transactions/send_money */
+  this.transactions.send_money = function(options, callback) {
+    var url = self.baseUrl + 'transactions/send_money';
+
+    log('post ' + url + ' with options ' + util.inspect(options));
+
+    post(url, options, callback);
   };
 
   this.transfers = {};

--- a/test/index.js
+++ b/test/index.js
@@ -18,7 +18,7 @@ var coinbase = new Coinbase({
 describe('coinbase.account.balance', function () {
   it('should return account balance', function (done) {
     coinbase.account.balance(function (err, data) {
-      if (err) throw err;
+      if (err) return done(err);
       log('data: ' + util.inspect(data, null, 5));
       data.should.have.property('amount');
       data.should.have.property('currency', 'BTC');
@@ -29,7 +29,7 @@ describe('coinbase.account.balance', function () {
 describe('coinbase.account.receiveAddress', function () {
   it('should return the user\'s current bitcoin receive address', function (done) {
     coinbase.account.receiveAddress(function (err, data) {
-      if (err) throw err;
+      if (err) return done(err);
       log('data: ' + util.inspect(data, null, 5));
       data.should.have.property('success', true);
       data.should.have.property('address');
@@ -41,7 +41,7 @@ describe('coinbase.account.receiveAddress', function () {
 describe('coinbase.account.generateReceiveAddress', function () {
   it('should generate a new receive address', function (done) {
     coinbase.account.generateReceiveAddress(function (err, data) {
-      if (err) throw err;
+      if (err) return done(err);
       log('data: ' + util.inspect(data, null, 5));
       data.should.have.property('success', true);
       data.should.have.property('address');
@@ -52,7 +52,7 @@ describe('coinbase.account.generateReceiveAddress', function () {
   it('should generate a new receive address with callback', function (done) {
     var url = 'https://www.example.com/callback';
     coinbase.account.generateReceiveAddress(url, function (err, data) {
-      if (err) throw err;
+      if (err) return done(err);
       log('data: ' + util.inspect(data, null, 5));
       data.should.have.property('success', true);
       data.should.have.property('address');
@@ -65,7 +65,7 @@ describe('coinbase.account.generateReceiveAddress', function () {
     var url = 'https://www.example.com/callback';
     var label = 'test';
     coinbase.account.generateReceiveAddress(url, label, function (err, data) {
-      if (err) throw err;
+      if (err) return done(err);
       log('data: ' + util.inspect(data, null, 5));
       data.should.have.property('success', true);
       data.should.have.property('address');
@@ -89,7 +89,7 @@ describe('coinbase.button', function () {
                   }
                 };
     coinbase.buttons.create(param, function (err, data) {
-      if (err) throw err;
+      if (err) return done(err);
       log('data: ' + util.inspect(data, null, 5));
       data.should.have.property('success', true);
       data.should.have.property('button');
@@ -105,25 +105,10 @@ describe('coinbase.button', function () {
     });
   });
 });
-describe('coinbase.buy', function () {
-  xit('should buy one btc', function (done) {
-    coinbase.buy({ name: 'test', qty: 1, price: { cents: 1, currency_iso: 'USD' } }, function (err, data) {
-      if (err) throw err;
-      log('data: ' + util.inspect(data, null, 5));
-      data.should.have.property('success', true);
-      data.should.have.property('transfer');
-      data.transfer.should.have.property('fees');
-      data.transfer.should.have.property('status');
-      data.transfer.should.have.property('btc');
-      data.btc.transfer.should.have.property('amount', 1);
-      done();
-    });
-  });
-});
 describe('coinbase.contacts', function () {
   it('should return the user\'s previously emailed contacts', function (done) {
     coinbase.contacts(function (err, data) {
-      if (err) throw err;
+      if (err) return done(err);
       log('data: ' + util.inspect(data, null, 5));
       data.should.have.property('contacts');
       data.should.have.property('total_count');
@@ -136,7 +121,7 @@ describe('coinbase.contacts', function () {
 describe('coinbase.currencies.list', function () {
   it('should return list of supported currencies', function (done) {
     coinbase.currencies.list(function (err, data) {
-      if (err) throw err;
+      if (err) return done(err);
       log('data: ' + util.inspect(data, null, 5));
       data.length.should.be.above(0);
       done();
@@ -146,7 +131,7 @@ describe('coinbase.currencies.list', function () {
 describe('coinbase.currencies.exchangeRates', function () {
   it('should return current currency exchange rates', function (done) {
     coinbase.currencies.exchangeRates(function (err, data) {
-      if (err) throw err;
+      if (err) return done(err);
       log('data: ' + util.inspect(data, null, 5));
       data.should.have.property('btc_to_usd');
       data.should.have.property('usd_to_btc');
@@ -157,7 +142,7 @@ describe('coinbase.currencies.exchangeRates', function () {
 describe('coinbase.orders.list', function () {
   it('should return list of supported orders', function (done) {
     coinbase.orders.list(function (err, data) {
-      if (err) throw err;
+      if (err) return done(err);
       log('data: ' + util.inspect(data, null, 5));
       data.should.have.property('orders');
       data.should.have.property('total_count');
@@ -169,17 +154,21 @@ describe('coinbase.orders.list', function () {
 });
 describe('coinbase.orders.get', function () {
   it('should return current currency exchange rates', function (done) {
-    coinbase.orders.get(0, function (err, data) {
-      if (err) throw err;
-      log('data: ' + util.inspect(data, null, 5));
-      done();
+    coinbase.orders.list(function (err, ordersList) {
+      if (err) return done(err);
+      if (ordersList.orders.length === 0) return done();
+      coinbase.orders.get(ordersList.orders[0].order.id, function (err, data) {
+        if (err) return done(err);
+        log('data: ' + util.inspect(data, null, 5));
+        done();
+      });
     });
   });
 });
 describe('coinbase.prices.buy', function () {
   it('should return the total buy price for some bitcoin amount', function (done) {
     coinbase.prices.buy(function (err, data) {
-      if (err) throw err;
+      if (err) return done(err);
       log('data: ' + util.inspect(data, null, 5));
       data.should.have.property('amount');
       data.should.have.property('currency');
@@ -190,7 +179,7 @@ describe('coinbase.prices.buy', function () {
 describe('coinbase.prices.sell', function () {
   it('should return the total sell price for some bitcoin amount', function (done) {
     coinbase.prices.sell(function (err, data) {
-      if (err) throw err;
+      if (err) return done(err);
       log('data: ' + util.inspect(data, null, 5));
       data.should.have.property('amount');
       data.should.have.property('currency');
@@ -201,7 +190,7 @@ describe('coinbase.prices.sell', function () {
 describe('coinbase.transactions.list', function () {
   it('should return the user\'s most recent transactions', function (done) {
     coinbase.transactions.list(function (err, data) {
-      if (err) throw err;
+      if (err) return done(err);
       log('data: ' + util.inspect(data, null, 5));
       data.should.have.property('current_user');
       data.should.have.property('balance');
@@ -213,26 +202,83 @@ describe('coinbase.transactions.list', function () {
 });
 describe('coinbase.transactions.get', function () {
   it('should return the details of an individual transaction', function (done) {
-    coinbase.transactions.get(0, function (err, data) {
-      if (err) throw err;
-      log('data: ' + util.inspect(data, null, 5));
-      data.should.have.property('transaction');
-      data.transaction.should.have.property('id');
-      data.transaction.should.have.property('amount');
-      done();
+    coinbase.transactions.list(function (err, txList) {
+      if (err) return done(err);
+      coinbase.transactions.get(txList.transactions[0].transaction.id, function (err, data) {
+        if (err) return done(err);
+        log('data: ' + util.inspect(data, null, 5));
+        data.should.have.property('transaction');
+        data.transaction.should.have.property('id');
+        data.transaction.should.have.property('amount');
+        done();
+      });
     });
   });
 });
 describe('coinbase.transfers.list', function () {
   it('should return the user\'s most recent transfers', function (done) {
     coinbase.transfers.list(function (err, data) {
-      if (err) throw err;
+      if (err) return done(err);
       log('data: ' + util.inspect(data, null, 5));
       data.should.have.property('transfers');
       data.should.have.property('total_count');
       data.should.have.property('num_pages');
       data.should.have.property('current_page');
       done();
+    });
+  });
+});
+
+
+/*
+ *
+ *      WARNING!: THESE TESTS BUY/SELL REAL BTC. 
+ *                BY DEFAULT THESE ARE SKIPPED
+ *
+ */
+describe.skip('WARNING', function() {
+  describe('coinbase.buy', function () {
+    it('should buy one btc', function (done) {
+      coinbase.buy({ name: 'test', qty: 1, price: { cents: 1, currency_iso: 'USD' } }, function (err, data) {
+        if (err) return done(err);
+        log('data: ' + util.inspect(data, null, 5));
+        data.should.have.property('success', true);
+        data.should.have.property('transfer');
+        data.transfer.should.have.property('fees');
+        data.transfer.should.have.property('status');
+        data.transfer.should.have.property('btc');
+        data.btc.transfer.should.have.property('amount', 1);
+        done();
+      });
+    });
+  });
+
+  describe('coinbase.transactions.send_money', function () {
+    var to = 'REPLACE_ME@SOMEEMAIL.FOO';
+    it('should send money and return the details of send_money transaction', function (done) {
+      var amount = '0.0000001';
+      coinbase.transactions.send_money({to: to, amount: amount, notes: 'btc4u'}, function (err, data) {
+        if (err) return done(err);
+        log('data: ' + util.inspect(data, null, 5));
+        data.should.have.property('success', true);
+        data.should.have.property('transaction');
+        data.transaction.should.have.property('id');
+        data.transaction.should.have.property('amount');
+        data.transaction.should.have.property('status', 'complete');
+        data.transaction.amount.should.have.property('amount');
+        Math.abs(Number(data.transaction.amount.amount)).should.be.eql(Number(amount));
+        done();
+      });
+    });
+
+    it('should send invalid amount and return CoinbaseError', function (done) {
+      var amount = '0.000000001'; // invalid amount
+      coinbase.transactions.send_money({to: to, amount: amount, notes: 'btc4u'}, function (err, data) {
+        err.should.have.property('error');
+        err.error.should.be.instanceOf(Array).and.have.lengthOf(1);
+        err.error[0].should.be.eql('You must enter a valid amount');
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
change log:
- implemented `send_money` (https://coinbase.com/api/doc/1.0/transactions/send_money.html)
- refactored the way errors were being handled.
  - try/catch should only be applied to `JSON.parse`, not to the callback. It was being applied to the success callback, so when tests failed because some assertion failed, it was being caught by the catch block and the test error was not bubbled to mocha.
  - also removed all the if/else and made the code more defensive and easy to follow (i.e. cut the flow if there was an error)
- moved all the "transaction tests" to the bottom with a warning and a `skip`
