### PR TITLE
fix buys endpoint url: use buys instead of buttons

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -164,7 +164,7 @@ function Coinbase (options) {
   /* POST https://coinbase.com/api/v1/buys */
   this.buy = function (param, callback) {
 
-    var url = self.baseUrl + 'buttons';
+    var url = self.baseUrl + 'buys';
 
     log('post ' + url);
 


### PR DESCRIPTION
This patch fixes what seems to have been a typo for buys functionality. Append 'buys' to the base url instead of 'buttons' and we get rid of the weird merchant and button permission errors. 